### PR TITLE
fixed bubble chart brush issue by moving updateChart() to endBrush()

### DIFF
--- a/js/bubblechart.js
+++ b/js/bubblechart.js
@@ -213,7 +213,7 @@ function drawChart(route_info, GPS_routes) {
         [padding.l, 0],
         [chartWidth, chartHeight],
       ])
-      .on("start brush", updateChart)
+      //.on("start brush", updateChart)
       .on("end", brushend)
   );
   //Adding size for cost
@@ -366,6 +366,7 @@ function drawChart(route_info, GPS_routes) {
     ); // This return TRUE or FALSE depending on if the points is in the selected area
   }
   function brushend() {
+    updateChart();
     if (!d3.event.selection) {
       polylines.removeFrom(map2);
     }


### PR DESCRIPTION
Now the brush itself has no latency, but it will still crash when too many nodes are selected in the end.